### PR TITLE
Fixed 'make install' generating wrong dropbox wrapper script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 
 install: libdropbox_ext4.so
 	install $^ $(INSTALL_DIR)/lib/ && \
-	echo -e "#!/bin/bash\n\nLD_PRELOAD=$(INSTALL_DIR)/lib/$^ exec /usr/bin/dropbox \"\$$@\"" > $(INSTALL_DIR)/bin/dropbox && \
+	cp dropbox $(INSTALL_DIR)/bin/dropbox && \
 	chmod 0755 $(INSTALL_DIR)/bin/dropbox
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ clean:
 
 install: libdropbox_ext4.so
 	install $^ $(INSTALL_DIR)/lib/ && \
-	cp dropbox $(INSTALL_DIR)/bin/dropbox && \
-	chmod 0755 $(INSTALL_DIR)/bin/dropbox
+	install dropbox $(INSTALL_DIR)/bin/dropbox
 
 uninstall:
 	rm -f $(INSTALL_DIR)/bin/dropbox && \

--- a/dropbox
+++ b/dropbox
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+Dir=$(dirname "$0")
+
+LD_PRELOAD="$Dir"/../lib/libdropbox_ext4.so exec /usr/bin/dropbox "$@"


### PR DESCRIPTION
I'm on Ubuntu 18.04 and `echo -e` outputs `-e` when run with '/bin/sh' (the default shell for make), rather than interpret it a "process C escape sequences" (like Bash does).

`make install` created the dropbox wrapper script with the wrong first line: -e #!/bin/bash

This patch replaced the echo in the Makefile with a copy of an external file. The new dropbox file uses `dirname` to be path-agnostic.

I haven't changed the python script, because it works, and it doesn't have the problem fixed by this patch, but it might be worth looking if it could be improved to copy my new `dropbox` script instead of generating it in place.